### PR TITLE
Add favorite limit and error handling

### DIFF
--- a/src/ListPage.tsx
+++ b/src/ListPage.tsx
@@ -116,15 +116,18 @@ const ListPage = () => {
 
   const handleFavoriteButtonClick = async(url: string, username: string) => {
     if (!favorites.includes(url)) {
+      if(favorites.length >= 5) {
+        setErrorState(true);
+        setErrorMessage("お気に入りは5つまでです。");
+        return;
+      }
       const userFavoritesRef = dbRef(database, "userFavorites/" + username);
       push(userFavoritesRef, {
         url: url,
       });
       await fetchFavorites();
-      console.log("お気に入りに追加");
       return;
     }
-    console.log("お気に入りから削除");
     const userFavoritesRef = dbRef(database, "userFavorites/" + username);
     await get(userFavoritesRef)
       .then((snapshot) => {


### PR DESCRIPTION
いいねできる数を一人5つまでとする

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- お気に入りの最大数を5つに制限する機能が追加されました。5つを超えるとエラーメッセージが表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->